### PR TITLE
Update main.cpp

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -146,7 +146,5 @@ int main(int argc, char *argv[]) {
   request.threads = threads;
   request.dropFirstRowAndColumn = dropFirstRowAndColumn;
   request.debug = debug;
-  wsiToDicomConverter::WsiToDcm::wsi2dcm(request);
-
-  return SUCCESS;
+  return wsiToDicomConverter::WsiToDcm::wsi2dcm(request);
 }


### PR DESCRIPTION
Old code, returned 1 on exit, which masked exceptions in wsi2dcm and made the code appear always end with a error code.  Now returns 0 if conversion succeeds or exception int generated in Wsi2dcm.