### PR TITLE
Fix a compilation error when using libjsoncpp 1.9.x

### DIFF
--- a/src/dcmTags.cpp
+++ b/src/dcmTags.cpp
@@ -25,7 +25,7 @@ static const char VALUE[] = "Value";
 DcmTags::DcmTags() {}
 
 inline Json::Value readJsonTag(Json::Value obj, std::string tag) {
-  if (obj[tag][VALUE] != nullptr) {
+  if (!obj[tag][VALUE].isNull()) {
     return obj[tag][VALUE][0];
   } else {
     return Json::Value();


### PR DESCRIPTION
Message is:

wsi-to-dicom-converter/src/dcmTags.cpp:28:26: error: use of deleted function ‘Json::Value::Value(std::nullptr_t)’
   28 |   if (obj[tag][VALUE] != nullptr) {
      |                          ^~~~~~~
In file included from /usr/include/jsoncpp/json/reader.h:11,
                 from /usr/include/jsoncpp/json/json.h:11,
                 from wsi-to-dicom-converter/src/dcmTags.cpp:19:
/usr/include/jsoncpp/json/value.h:345:3: note: declared here
  345 |   Value(std::nullptr_t ptr) = delete;
      |   ^~~~~

Closes: #93