### PR TITLE
Update endToEndTest.sh

### DIFF
--- a/endToEnd/endToEndTest.sh
+++ b/endToEnd/endToEndTest.sh
@@ -25,8 +25,11 @@ compare () {
 }
 
 
-#building binaries
-bash ./cloud_build/ubuntuBuild.sh
+if [ "$1" !=  "SKIP_BUILD_ENVIRONMENT" ]
+then
+  #building binaries
+  bash ./cloud_build/ubuntuBuild.sh
+fi
 
 #set enviromnental vars for DCMTK
 export DCMDICTPATH=/usr/local/share/dcmtk/dicom.dic


### PR DESCRIPTION
Add support for optional flag to skip building the environment.  To support calling end2End tests in prebuilt envs.